### PR TITLE
Clean dummy po files when they're generated

### DIFF
--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -27,8 +27,8 @@ class Runner:
 
     def __call__(self, **kwargs):
         args = self.parser.parse_known_args(self.args)[0]
-        for k, v in kwargs.items():
-            setattr(args, k, v)
+        for key, val in kwargs.items():
+            setattr(args, key, val)
         if args.config:
             config.CONFIGURATION = config.Configuration(args.config)
         else:

--- a/i18n/config.py
+++ b/i18n/config.py
@@ -1,7 +1,8 @@
 import os
 
 import yaml
-from path import path
+# Possibly a Pylint bug in the most recent version that causes it to not recognize module members
+from path import path  # pylint: disable=no-name-in-module
 
 # BASE_DIR is the working directory to execute django-admin commands from.
 # Typically this should be the 'edx-platform' directory.

--- a/i18n/dummy.py
+++ b/i18n/dummy.py
@@ -26,7 +26,8 @@ from __future__ import print_function
 import re
 
 import polib
-from path import path
+# Possibly a Pylint bug in the most recent version that causes it to not recognize module members
+from path import path  # pylint: disable=no-name-in-module
 
 from i18n import config, Runner
 from i18n.converter import Converter

--- a/i18n/dummy.py
+++ b/i18n/dummy.py
@@ -30,6 +30,7 @@ from path import path
 
 from i18n import config, Runner
 from i18n.converter import Converter
+from i18n.generate import clean_pofile
 
 
 class BaseDummyConverter(Converter):
@@ -186,6 +187,7 @@ def make_dummy(filename, locale, converter):
     new_file = new_filename(filename, locale)
     new_file.parent.makedirs_p()
     pofile.save(new_file)
+    clean_pofile(new_file)
 
 
 def new_filename(original_filename, new_locale):

--- a/i18n/extract.py
+++ b/i18n/extract.py
@@ -23,7 +23,8 @@ import logging
 import sys
 import polib
 
-from path import path
+# Possibly a Pylint bug in the most recent version that causes it to not recognize module members
+from path import path  # pylint: disable=no-name-in-module
 
 from i18n import config, Runner
 from i18n.execute import execute, remove_file
@@ -37,7 +38,7 @@ DEVNULL = open(os.devnull, 'wb')
 
 def base(path1, *paths):
     """Return a relative path from config.BASE_DIR to path1 / paths[0] / ... """
-    return config.BASE_DIR.relpathto(path1.joinpath(*paths))
+    return config.BASE_DIR.relpathto(path1.joinpath(*paths))  # pylint: disable=no-value-for-parameter
 
 
 class Extract(Runner):
@@ -131,7 +132,7 @@ class Extract(Runner):
             # Import the app to find out where it is.  Then use pybabel to extract
             # from that directory.
             app_module = importlib.import_module(app_name)
-            app_dir = path(app_module.__file__).dirname().dirname()
+            app_dir = path(app_module.__file__).dirname().dirname()  # pylint: disable=no-value-for-parameter
             output_file = source_msgs_dir / (app_name + ".po")
             files_to_clean.add(output_file)
 

--- a/i18n/generate.py
+++ b/i18n/generate.py
@@ -38,7 +38,7 @@ def merge(locale, target='django.po', sources=('django-partial.po',), fail_if_mi
     just return silently.
 
     """
-    LOG.info('Merging {target} for locale {locale}'.format(target=target, locale=locale))
+    LOG.info('Merging %s locale %s', target, locale)
     locale_directory = config.CONFIGURATION.get_messages_dir(locale)
     try:
         validate_files(locale_directory, sources)
@@ -113,6 +113,7 @@ def validate_files(directory, files_to_merge):
 
 
 class Generate(Runner):
+    """Generate merged and compiled message files."""
     def add_args(self):
         self.parser.description = "Generate merged and compiled message files."
         self.parser.add_argument("--strict", action='store_true', help="Complain about missing files.")

--- a/i18n/main.py
+++ b/i18n/main.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 import importlib
 import sys
-from path import path
+# Possibly a Pylint bug in the most recent version that causes it to not recognize module members
+from path import path  # pylint: disable=no-name-in-module
 
 
 def get_valid_commands():

--- a/i18n/segment.py
+++ b/i18n/segment.py
@@ -64,7 +64,7 @@ def segment_pofile(filename, segments):
     writing_msg = "Writing {num} entries to {file}"
 
     source_po = polib.pofile(filename)
-    LOG.info(reading_msg.format(file=filename, num=len(source_po)))
+    LOG.info(reading_msg.format(file=filename, num=len(source_po)))  # pylint: disable=logging-format-interpolation
 
     # A new pofile just like the source, but with no messages. We'll put
     # anything not segmented into this file.
@@ -107,9 +107,9 @@ def segment_pofile(filename, segments):
     for segment_file, pofile in segment_po_files.items():
         out_file = filename.dirname() / segment_file
         if len(pofile) == 0:
-            LOG.error("No messages to write to {file}, did you run segment twice?".format(file=out_file))
+            LOG.error("No messages to write to %s, did you run segment twice?", out_file)
         else:
-            LOG.info(writing_msg.format(file=out_file, num=len(pofile)))
+            LOG.info(writing_msg.format(file=out_file, num=len(pofile)))  # pylint: disable=logging-format-interpolation
             pofile.save(out_file)
             files_written.add(out_file)
 

--- a/i18n/validate.py
+++ b/i18n/validate.py
@@ -143,9 +143,9 @@ def check_messages(filename, report_empty=False):
                     prob_file.write(u"{}\n".format(tx_filler.fill(translation)))
                 prob_file.write(u"\n")
 
-        log.error(" {0} problems in {1}, details in .prob file".format(len(problems), filename))
+        log.error(" %s problems in %s, details in .prob file", len(problems), filename)
     else:
-        log.info(" No problems found in {0}".format(filename))
+        log.info(" No problems found in %s", filename)
 
 
 class Validate(Runner):
@@ -188,7 +188,7 @@ class Validate(Runner):
             root = config.LOCALE_DIR / language
             # Assert that a directory for this language code exists on the system
             if not root.isdir():
-                log.error(" {0} is not a valid directory.\nSkipping language '{1}'".format(root, language))
+                log.error(" %s is not a valid directory.\nSkipping language '%s'", root, language)
                 continue
             # If we found the language code's directory, validate the files.
             validate_po_files(root, args.empty)

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,8 @@ rednose=1
 #pdb=1
 
 [pep8]
-ignore=E501
+# error codes: http://pep8.readthedocs.org/en/latest/intro.html#error-codes
+# E501: line too long
+# E731: do not assign a lambda expression, use a def
+ignore=E501,E731
+


### PR DESCRIPTION
@nedbat - clean the constituent po files for dummy languages as they are generated.

This was causing problems and people on the mailing list were complaining about the error (because it looks really bad when it pops up in your console:

```
edxapp@precise64:~/edx-platform$ i18n_tool validate
ERROR:i18n.validate: 1 problems in /edx/app/edxapp/edx-platform/conf/locale/es_ES/LC_MESSAGES/djangojs.po, details in .prob file
WARNING:i18n.validate:
fake2/LC_MESSAGES/underscore-studio.po:132: 'msgstr' is not a valid Python format string, unlike 'msgid'. Reason: The character that terminates the directive number 1 is not a valid conversion specifier.
msgfmt: found 1 fatal error
```

(especially since "fatal error" sounds really bad to less-techy folk). This fix cleans the composite PO files for the dummy langs, so we don't see this.