### PR TITLE
Fix translation conflicts on file merge [LOC-67]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dist/
 \#*\#
 *.egg-info
 conf/locale/fake2/LC_MESSAGES/*.mo
+*.prob
+*.dup

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - pip install -r requirements.txt
 script:
   - coverage run -m nose
-  - pep8 .
+  - pep8 i18n
   - scripts/max_pylint_violations 20
 after_success:
   - coveralls

--- a/conf/locale/fake2/LC_MESSAGES/django-partial.po
+++ b/conf/locale/fake2/LC_MESSAGES/django-partial.po
@@ -26,6 +26,5 @@ msgid "Discussion"
 msgstr "Đᴉsɔnssᴉøn"
 
 #: cms/djangoapps/contentstore/views/component.py
-#: lms/djangoapps/class_dashboard/dashboard_data.py
 msgid "Problem"
 msgstr "Ᵽɹøblǝɯ"

--- a/conf/locale/fake2/LC_MESSAGES/django-studio.po
+++ b/conf/locale/fake2/LC_MESSAGES/django-studio.po
@@ -34,3 +34,7 @@ msgstr "ɯnsʇ ɥɐʌǝ ɐʇ lǝɐsʇ ønǝ ƃɹønd"
 #: cms/djangoapps/contentstore/course_info_model.py
 msgid "Invalid course update id."
 msgstr "Ɨnʌɐlᴉd ɔønɹsǝ nddɐʇǝ ᴉd."
+
+#: cms/djangoapps/contentstore/views/component.py
+msgid "Problem"
+msgstr "Ṗṛöḅḷëṁ"

--- a/conf/locale/fake2/LC_MESSAGES/wiki.po
+++ b/conf/locale/fake2/LC_MESSAGES/wiki.po
@@ -37,3 +37,7 @@ msgstr "Ɨnᴉʇᴉɐl ʇᴉʇlǝ øɟ ʇɥǝ ɐɹʇᴉɔlǝ. Mɐʎ bǝ øʌǝɹ
 #: wiki/forms.py
 msgid "Type in some contents"
 msgstr "Ŧʎdǝ ᴉn søɯǝ ɔønʇǝnʇs"
+
+#: wiki/forms.py
+msgid "Problem"
+msgstr "Рѓоъlэм"

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -6,7 +6,6 @@ import os
 import random
 import re
 import sys
-import shutil
 import string
 import subprocess
 from unittest import TestCase
@@ -73,9 +72,7 @@ class TestGenerate(TestCase):
                     datetime.fromtimestamp(os.path.getmtime(file_path), UTC) >= self.start_time,
                     msg='File not recently modified: %s' % file_path
                 )
-            # Segmenting means that the merge headers don't work they way they
-            # used to, so don't make this check for now. I'm not sure if we'll
-            # get the merge header back eventually, or delete this code eventually.
+            # Assert merge headers look right
             file_path = os.path.join(CONFIGURATION.get_messages_dir(locale), filename + '.po')
             self.assert_merge_headers(file_path, num_headers)
 
@@ -99,20 +96,28 @@ class TestGenerate(TestCase):
             msg="Found %s (should be %s) merge comments in the header for %s" % (len(match), num_headers, file_path)
         )
 
-    def test_resolve_merge_conflicts(self):
+    @patch('i18n.generate.LOG')
+    def test_resolve_merge_conflicts(self, mock_log):
         django_po_path = os.path.join(CONFIGURATION.get_messages_dir('fake2'), 'django.po')
         # File ought to have been generated in test_main
-        if not os.path.exists(django_po_path):
-            generate.main(verbose=0, strict=False)
+        # if not os.path.exists(django_po_path):
+        generate.main(verbose=0, strict=False)
 
-        django_po_file = open(django_po_path, 'r')
-        po_lines = django_po_file.read()
+        with open(django_po_path, 'r') as django_po_file:
+            po_lines = django_po_file.read()
 
         # check that there are no merge conflicts present
         # "#-#-#-#-#  django-partial.po (edx-platform)  #-#-#-#-#\n"
         pattern = re.compile('\"#-#-#-#-#.*#-#-#-#-#', re.M)
         match = pattern.findall(po_lines)
         self.assertEqual(len(match), 0, msg="Error, found merge conflicts in django.po: %s" % match)
+        # Validate that the appropriate log warnings were shown
+        self.assertTrue(mock_log.error.called)
+        self.assertIn(
+            " %s duplicates in %s, details in .dup file",
+            # the first item of call_args is the call arguments themselves as a tuple
+            mock_log.error.call_args[0]
+        )
 
 
 def random_name(size=6):


### PR DESCRIPTION
Unresolved Translation conflicts between the different resources.

EX:
```
#: cms/djangoapps/contentstore/views/videos.py
#: lms/djangoapps/shoppingcart/reports.py
#: lms/templates/open_ended_problems/open_ended_problems.html
#: lms/templates/shoppingcart/receipt.html
#: lms/templates/shoppingcart/verified_cert_receipt.html
#, fuzzy
msgid "Status"
msgstr ""
"#-#-#-#-#  django-partial.po (edx-platform)  #-#-#-#-#\n"
"الحالة\n"
"#-#-#-#-#  mako.po (edx-platform)  #-#-#-#-#\n"
"حالة"
```

When these strings are served to users, they look, well, awful!

Resolution: change the generate script to pick the first translation, rather than marking as fuzzy and showing multiple. Emit a log warning to identify where conflicts are, so there is opportunity to resolve them.

Ultimately it would be good to wrap up the duplicate items warnings into a report.