### PR TITLE
Add .coveragerc file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = True
+source = .
+
+omit =
+    setup.py
+    conf/*


### PR DESCRIPTION
Coveralls reports 40% coverage in part because it's tracking ALL files, not just repo files. See https://coveralls.io/builds/2835407 particularly:

![screen shot 2015-06-17 at 12 06 20 am](https://cloud.githubusercontent.com/assets/1985317/8199504/bbb9b140-1484-11e5-9120-6276e6c9ad5c.png)
