### PR TITLE
LOC-89 RTL dummy language translates %s

### DIFF
--- a/i18n/converter.py
+++ b/i18n/converter.py
@@ -26,6 +26,7 @@ class Converter(object):
         (<[^>]+>)           |       # <tag>
         ({[^}]+})           |       # {tag}
         (%\([\w]+\)\w)      |       # %(tag)s
+        (%[sdrxf])          |       # %s
         (&\w+;)             |       # &entity;
         (&\#\d+;)           |       # &#1234;
         (&\#x[0-9a-f]+;)            # &#xABCD;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,11 @@
 coveralls
-pylint
-pep8
-rednose
+ddt
 django
+mock
+nose
+path.py
+pep8
+polib
+pylint
+pytz
+rednose

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ console_scripts = ['i18n_tool = i18n.main:main']
 
 setup(
     name='i18n_tools',
-    version='0.1',
+    version='0.1.3',
     description='edX i18n tools',
     packages=[
         'i18n',

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -48,6 +48,9 @@ class TestConverter(TestCase):
         # .format-style tags
         ('The {0} barn is {1!r}.',
          'THE {0} BARN IS {1!r}.'),
+        # Not-as-useful Python tags
+        ('A string (%s) and a number (%d)',
+         'A STRING (%s) AND A NUMBER (%d)'),
         # HTML entities
         ('<b>&copy; 2013 edX, &#xa0;</b>',
          '<b>&copy; 2013 EDX, &#xa0;</b>'),

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -46,11 +46,14 @@ class TestDummy(TestCase):
 
         (u"don't convert %(name)s tags on %(date)s",
          u"dön't çönvért %(name)s tägs ön %(date)s Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢#"),
+
+        (u"don't convert %s tags on %s",
+         u"dön't çönvért %s tägs ön %s Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢#"),
     )
     def test_dummy(self, data):
         """
         Tests with a dummy converter (adds spurious accents to strings).
-        Assert that embedded HTML and python tags are not converted.
+        Assert that embedded HTML and Python tags are not converted.
         """
         source, expected = data
         result = self.converter.convert(source)

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -76,3 +76,31 @@ class TestDummy(TestCase):
         result = entry.msgstr_plural
         self.assertUnicodeEquals(result['0'], expected_s)
         self.assertUnicodeEquals(result['1'], expected_p)
+
+    @ddt.data(
+        (u"sign in",
+         u"سهلر هر"),
+
+        (u"my name is Bond",
+         u"وغ رشوث هس زخري"),
+
+        (u"hello my name is Bond, James Bond",
+         u"اثممخ وغ رشوث هس زخري, تشوثس زخري"),
+
+        (u"don't convert <a href='href'>tag ids</a>",
+         u"يخر'ف ذخردثقف <a href='href'>فشل هيس</a>"),
+
+        (u"don't convert %(name)s tags on %(date)s",
+         u"يخر'ف ذخردثقف %(name)s فشلس خر %(date)s"),
+
+        (u"don't convert %s tags on %s",
+         u"يخر'ف ذخردثقف %s فشلس خر %s"),
+    )
+    def test_dummy_arabic(self, data):
+        """
+        Tests with a dummy Arabic converter for RTL.
+        Assert that embedded HTML and Python tags are not converted.
+        """
+        source, expected = data
+        result = dummy.ArabicDummy().convert(source)
+        self.assertUnicodeEquals(result, expected)


### PR DESCRIPTION
Turns out eo also translates %s, but eo only changes vowels, so you can't see that it's translating it.

The fix is simple, but we should be forbidding these %s tags anyway, certainly if there is more than one in a string.
@sarina ?