### PR TITLE
Using domain argument for extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist/
 *.mo
 *.prob
 *.dup
+.idea/

--- a/i18n/extract.py
+++ b/i18n/extract.py
@@ -103,12 +103,12 @@ class Extract(Runner):
         if ignores:
             makemessages += " " + ignores
 
-        # Extract strings from django source files, including .py files.
-        make_django_cmd = makemessages + ' --extension html'
+        # Extract strings from django source files (*.py, *.html, *.txt).
+        make_django_cmd = makemessages + ' -d django'
         execute(make_django_cmd, working_directory=config.BASE_DIR, stderr=stderr)
 
-        # Extract strings from Javascript source files.
-        make_djangojs_cmd = makemessages + ' -d djangojs --extension js'
+        # Extract strings from Javascript source files (*.js).
+        make_djangojs_cmd = makemessages + ' -d djangojs'
         execute(make_djangojs_cmd, working_directory=config.BASE_DIR, stderr=stderr)
 
         # makemessages creates 'django.po'. This filename is hardcoded.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ console_scripts = ['i18n_tool = i18n.main:main']
 
 setup(
     name='i18n_tools',
-    version='0.1.3',
+    version='0.1.4',
     description='edX i18n tools',
     packages=[
         'i18n',


### PR DESCRIPTION
Use the domain argument on makemessages to determine which files to parse for translation. By default the django domain will pull data for all *.py, *.html and *.txt files. The djangojs domain will pull data for all *.js files.

The makemessages docs are available at https://docs.djangoproject.com/en/1.8/ref/django-admin/#makemessages. The `-d` parameter is compatible with Django 1.4.x.

Fixes #23 

@sarina @nedbat @singingwolfboy 