### PR TITLE
A few fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,15 @@ Details of the config.yaml file are in `edx-platform/conf/locale/config.yaml
 <https://github.com/edx/edx-platform/blob/master/conf/locale/config.yaml>`_
 
 
+Changes
+=======
+
+Unreleased
+----------
+
+* ``i18n_tool validate`` no longer leaves an unneeded messages.mo file behind.
+
+
 Development
 ===========
 

--- a/README.rst
+++ b/README.rst
@@ -1,35 +1,35 @@
-i18n Tools |build-status| |coverage-status|
-===========================================
+edX i18n Tools |build-status| |coverage-status|
+###############################################
 
 Installing
-----------
+==========
 
 ``python setup.py install``
 
 Running
--------
+=======
 
 Running commands from the edx-platform directory will default to loading the
 configuration at ``./conf/locale/config.yaml``. You can specify a different
 configuration file with the ``--config`` argument.
 
- * ``i18n_tool dummy``
- * ``i18n_tool extract``
- * ``i18n_tool generate``
- * ``i18n_tool segment``
- * ``i18n_tool transifex``
- * ``i18n_tool validate``
+* ``i18n_tool dummy``
+* ``i18n_tool extract``
+* ``i18n_tool generate``
+* ``i18n_tool segment``
+* ``i18n_tool transifex``
+* ``i18n_tool validate``
 
 
 Configuration
--------------
+=============
 
 Details of the config.yaml file are in `edx-platform/conf/locale/config.yaml
 <https://github.com/edx/edx-platform/blob/master/conf/locale/config.yaml>`_
 
 
 Development
------------
+===========
 
 To work on this code:
 
@@ -42,7 +42,7 @@ To work on this code:
    $ nosestests
 
    If you have failures because ``msgcat`` failed, you may need to install it,
-   and adjust your PATH to include it.  On a Mac::
+   and adjust your PATH to include it.  On a Mac, for example::
 
    $ brew install gettext
    $ PATH=/usr/local/Cellar/gettext/0.19.3/bin/:$PATH nosetests

--- a/i18n/generate.py
+++ b/i18n/generate.py
@@ -175,6 +175,9 @@ class Generate(Runner):
         # Dummy text is not required. Don't raise exception if files are missing.
         for locale in config.CONFIGURATION.dummy_locales:
             merge_files(locale, fail_if_missing=False)
+        # Merge the source locale, so we have the canonical .po files.
+        if config.CONFIGURATION.source_locale not in langs:
+            merge_files(config.CONFIGURATION.source_locale, fail_if_missing=args.strict)
 
         compile_cmd = 'django-admin.py compilemessages -v{}'.format(args.verbose)
         if args.verbose:

--- a/i18n/validate.py
+++ b/i18n/validate.py
@@ -46,7 +46,7 @@ def msgfmt_check_po_file(filename):
     """
     # Use relative paths to make output less noisy.
     rfile = os.path.relpath(filename, config.LOCALE_DIR)
-    out, err = call('msgfmt -c {}'.format(rfile), working_directory=config.LOCALE_DIR)
+    out, err = call('msgfmt -c -o /dev/null {}'.format(rfile), working_directory=config.LOCALE_DIR)
     if err != '':
         log.info('\n' + out)
         log.warn('\n' + err)


### PR DESCRIPTION
* Give the README a change history.
* When validating, avoid writing a messages.mo file that we don't want.
* Merge the en files, so that we have a en/django.po and en/djangojs.po