### PR TITLE
Push and Pull can work on specific resources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ To work on this code:
 
 #. Run tests::
 
-   $ nosestests
+   $ nosetests
 
    If you have failures because ``msgcat`` failed, you may need to install it,
    and adjust your PATH to include it.  On a Mac, for example::

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,13 @@ Details of the config.yaml file are in `edx-platform/conf/locale/config.yaml
 Changes
 =======
 
+v0.3
+----
+
+* ``i18n_tool transifex push`` and ``i18n_tool transifex pull`` now can take
+  optional resource names on the command line.  If not provided, all resources
+  are pushed/pulled.
+
 v0.2.1
 ------
 

--- a/i18n/transifex.py
+++ b/i18n/transifex.py
@@ -12,11 +12,19 @@ from i18n.extract import EDX_MARKER
 TRANSIFEX_HEADER = u'edX community translations have been downloaded from {}'
 
 
-def push():
+def push(*resources):
     """
-    Push translation source English files to Transifex
+    Push translation source English files to Transifex.
+
+    Arguments name specific resources to push. Otherwise, push all the source
+    files.
     """
-    execute('tx push -s')
+    cmd = 'tx push -s'
+    if resources:
+        for resource in resources:
+            execute(cmd + ' -r {resource}'.format(resource=resource))
+    else:
+        execute(cmd)
 
 
 def push_all():
@@ -34,15 +42,24 @@ def push_all():
         print("\n")
 
 
-def pull():
+def pull(*resources):
     """
     Pull translations from all languages listed in conf/locale/config.yaml
-    where there is at least 10% reviewed translations
+    where there is at least 10% reviewed translations.
+
+    If arguments are provided, they are specific resources to pull.  Otherwise,
+    all resources are pulled.
+
     """
     print("Pulling conf/locale/config.yaml:locales from Transifex...")
 
     for lang in config.CONFIGURATION.translated_locales:
-        execute('tx pull --mode=reviewed -l ' + lang)
+        cmd = 'tx pull -f --mode=reviewed -l {lang}'.format(lang=lang)
+        if resources:
+            for resource in resources:
+                execute(cmd + ' -r {resource}'.format(resource=resource))
+        else:
+            execute(cmd)
     clean_translated_locales()
 
 
@@ -138,12 +155,13 @@ class Transifex(Runner):
     """Define the command class"""
     def add_args(self):
         self.parser.add_argument("command", help="push or pull")
+        self.parser.add_argument("arg", nargs="*")
 
     def run(self, args):
         if args.command == "push":
-            push()
+            push(*args.arg)
         elif args.command == "pull":
-            pull()
+            pull(*args.arg)
         elif args.command == "pull_all":
             pull_all()
         elif args.command == "ltr":

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
-from setuptools import setup
 
-console_scripts = ['i18n_tool = i18n.main:main']
+from setuptools import setup
 
 setup(
     name='i18n_tools',
-    version='0.2.1',
+    version='0.3',
     description='edX i18n tools',
     packages=[
         'i18n',
@@ -14,6 +13,8 @@ setup(
     tests_require=["rednose"],
     test_suite='nose.collector',
     entry_points={
-        'console_scripts': console_scripts
-    }
+        'console_scripts': [
+            'i18n_tool = i18n.main:main',
+        ],
+    },
 )

--- a/tests/test_transifex.py
+++ b/tests/test_transifex.py
@@ -35,6 +35,19 @@ class TestTransifex(TestCase):
             self.mock_execute.call_args[0][0]
         )
 
+    def test_push_command_with_resources(self):
+        # Call the push command
+        transifex.push("foo.1", "foo.2")
+
+        call_args = [
+            ('tx push -s -r foo.1',),
+            ('tx push -s -r foo.2',),
+        ]
+        self.assertEqual(
+            call_args,
+            [callarg[0] for callarg in self.mock_execute.call_args_list]
+        )
+
     def test_push_all_command(self):
         # Call the push_all command
         with mockRawInput('Y'):
@@ -48,10 +61,28 @@ class TestTransifex(TestCase):
     def test_pull_command(self):
         # Call the pull command
         transifex.pull()
-        # conf/locale/config.yaml specifies two non-source locales, 'fr' and 'zh_CN'
-        self.assertEqual(2, self.mock_execute.call_count)
 
-        call_args = [('tx pull --mode=reviewed -l fr',), ('tx pull --mode=reviewed -l zh_CN',)]
+        # conf/locale/config.yaml specifies two non-source locales, 'fr' and 'zh_CN'
+        call_args = [
+            ('tx pull -f --mode=reviewed -l fr',),
+            ('tx pull -f --mode=reviewed -l zh_CN',),
+        ]
+        self.assertEqual(
+            call_args,
+            [callarg[0] for callarg in self.mock_execute.call_args_list]
+        )
+
+    def test_pull_command_with_resources(self):
+        # Call the pull command
+        transifex.pull("foo.1", "foo.2")
+
+        # conf/locale/config.yaml specifies two non-source locales, 'fr' and 'zh_CN'
+        call_args = [
+            ('tx pull -f --mode=reviewed -l fr -r foo.1',),
+            ('tx pull -f --mode=reviewed -l fr -r foo.2',),
+            ('tx pull -f --mode=reviewed -l zh_CN -r foo.1',),
+            ('tx pull -f --mode=reviewed -l zh_CN -r foo.2',),
+        ]
         self.assertEqual(
             call_args,
             [callarg[0] for callarg in self.mock_execute.call_args_list]


### PR DESCRIPTION
To support release-specific translations (like dogwood.po and dogwood-js.po), we need i18n_tools to support pushing and pulling only specific resource files.