### PR TITLE
Handle missing files/directories in extract

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,11 @@ Details of the config.yaml file are in `edx-platform/conf/locale/config.yaml
 Changes
 =======
 
+v0.3.8
+------
+
+* Fixes for extract to handle when expected directories/files are not present.
+
 v0.3.7
 ------
 

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '0.3.7'
+__version__ = '0.3.8'
 
 
 class Runner:

--- a/i18n/extract.py
+++ b/i18n/extract.py
@@ -56,15 +56,22 @@ class Extract(Runner):
         """
         Rename a file in the source directory.
         """
-        os.rename(self.source_msgs_dir.joinpath(src), self.source_msgs_dir.joinpath(dst))
+        src_path = self.source_msgs_dir.joinpath(src)
+        dst_path = self.source_msgs_dir.joinpath(dst)
 
-    def run(self, args):
+        # Only rename files that exist.
+        if os.path.exists(src_path):
+            os.rename(src_path, dst_path)
+
+    def run(self, args):  # pylint: disable=too-many-statements
         """
         Main entry point of script
         """
         logging.basicConfig(stream=sys.stdout, level=logging.INFO)
         configuration = self.configuration
         configuration.locale_dir.parent.makedirs_p()
+        configuration.source_messages_dir.makedirs_p()
+
         # pylint: disable=attribute-defined-outside-init
         self.source_msgs_dir = configuration.source_messages_dir
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='edx-i18n-tools',
-    version='0.3.7',
+    version='0.3.8',
     description='edX Internationalization Tools',
     author='edX',
     author_email='oscm@edx.org',


### PR DESCRIPTION
When used for the first time, or in non-django environments, the extract tool fails because it cannot find and rename django.po. This PR adds a check to ensure that files exist before we attempt to rename them. I also adds a call to create the expected output directory structure if it doesn't already exist. 