### PR TITLE
Added Support for Django 1.11 and python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,20 @@ language: python
 python:
   - 2.7
   - 3.5
+  - 3.6
 
 env:
   - TOXENV=django18
   - TOXENV=django19
   - TOXENV=django110
+  - TOXENV=django111
 
 matrix:
  include:
-  - python: 3.5
+  - python: 3.6
     env: TOXENV=quality
+    python: 3.6
+    env: TOXENV=django111
 
 cache:
     directories:

--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Sarina Canelake <sarina@edx.org>
 Steve Strassmann <straz@edx.org>
 Will Daly <will@edx.org>
 Dave St.Germain <dstgermain@edx.org>
+Ahsan Ul Haq <ahsan@edx.org>

--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,11 @@ Details of the config.yaml file are in `edx-platform/conf/locale/config.yaml
 Changes
 =======
 
+v0.3.8
+------
+
+* Added support for Django 1.11 and Python 3.6
+
 v0.3.7
 ------
 

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '0.3.7'
+__version__ = '0.3.8'
 
 
 class Runner:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='edx-i18n-tools',
-    version='0.3.7',
+    version='0.3.8',
     description='edX Internationalization Tools',
     author='edX',
     author_email='oscm@edx.org',
@@ -13,7 +13,7 @@ setup(
         'i18n',
     ],
     install_requires=[
-        'django>=1.8,<1.11',
+        'django>=1.8,<2.0',
         'polib',
         'path.py>=7.0',
         'pyYaml',
@@ -34,8 +34,11 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Framework :: Django',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py{27,35}-django{18,19,110},quality
+envlist = py{27,35}-django{18,19,110,111}, py36-django111, quality
 
 [testenv]
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
     -rtest_requirements.txt
 
 commands =


### PR DESCRIPTION
LEARNER-1182
This commit will add the support for django 1.11 and python 3.6