### PR TITLE
Decode byte strings returned by call to better support python3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,11 @@ Details of the config.yaml file are in `edx-platform/conf/locale/config.yaml
 Changes
 =======
 
+v0.3.9
+------
+
+* Fix Python 3 issues in validate.
+
 v0.3.8
 ------
 

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '0.3.8'
+__version__ = '0.3.9'
 
 
 class Runner:

--- a/i18n/execute.py
+++ b/i18n/execute.py
@@ -25,7 +25,7 @@ def call(command, working_directory=config.BASE_DIR):
     """
     Executes shell command in a given working_directory.
     Command is a list of strings to execute as a command line.
-    Returns a tuple of two strings: (stdout, stderr)
+    Returns a tuple of two byte strings: (stdout, stderr)
 
     """
     LOG.info(command)
@@ -39,7 +39,7 @@ def remove_file(filename, verbose=True):
     Attempt to delete filename.
     log is boolean. If true, removal is logged.
     Log a warning if file does not exist.
-    Logging filenames are releative to config.BASE_DIR to cut down on noise in output.
+    Logging filenames are relative to config.BASE_DIR to cut down on noise in output.
     """
     if verbose:
         LOG.info('Deleting file %s', os.path.relpath(filename, config.BASE_DIR))

--- a/i18n/validate.py
+++ b/i18n/validate.py
@@ -53,9 +53,9 @@ def msgfmt_check_po_file(locale_dir, filename):
     # Use relative paths to make output less noisy.
     rfile = os.path.relpath(filename, locale_dir)
     out, err = call('msgfmt -c -o /dev/null {}'.format(rfile), working_directory=locale_dir)
-    if err != '':
-        log.info('\n' + out)
-        log.warning('\n' + err)
+    if err:
+        log.info(u'\n' + out.decode('utf8'))
+        log.warning(u'\n' + err.decode('utf8'))
 
 
 def tags_in_string(msg):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='edx-i18n-tools',
-    version='0.3.8',
+    version='0.3.9',
     description='edX Internationalization Tools',
     author='edX',
     author_email='oscm@edx.org',


### PR DESCRIPTION
The call method is expected to return a tuple of strings (stdout, stderr), but when using python3 it returns a tuple of byte strings. This breaks the behavior of the validate command, which expects to be able to use the return values from call as normal strings.