### PR TITLE
Changes to support renaming zh-cn to zh-hans

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Steve Strassmann <straz@edx.org>
 Will Daly <will@edx.org>
 Dave St.Germain <dstgermain@edx.org>
 Ahsan Ul Haq <ahsan@edx.org>
+Brian Mesick <bmesick@edx.org>

--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,10 @@ Details of the config.yaml file are in `edx-platform/conf/locale/config.yaml
 
 Changes
 =======
+v0.3.10
+-------
+
+* Add support for edx_lang_map in config.yaml to share translations across language codes.
 
 v0.3.9
 ------

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '0.3.9'
+__version__ = '0.3.10'
 
 
 class Runner:

--- a/i18n/config.py
+++ b/i18n/config.py
@@ -27,7 +27,7 @@ class Configuration(object):
         'source_locale': 'en',
         'third_party': [],
         'TRANSIFEX_URL': 'https://www.transifex.com/open-edx/edx-platform/',
-        'edx_lang_map': {}
+        'edx_lang_map': {},
     }
 
     def __init__(self, filename=None, root_dir=None):

--- a/i18n/config.py
+++ b/i18n/config.py
@@ -27,6 +27,7 @@ class Configuration(object):
         'source_locale': 'en',
         'third_party': [],
         'TRANSIFEX_URL': 'https://www.transifex.com/open-edx/edx-platform/',
+        'edx_lang_map': {}
     }
 
     def __init__(self, filename=None, root_dir=None):

--- a/i18n/extract.py
+++ b/i18n/extract.py
@@ -56,7 +56,10 @@ class Extract(Runner):
         """
         Rename a file in the source directory.
         """
-        os.rename(self.source_msgs_dir.joinpath(src), self.source_msgs_dir.joinpath(dst))
+        try:
+            os.rename(self.source_msgs_dir.joinpath(src), self.source_msgs_dir.joinpath(dst))
+        except OSError:
+            pass
 
     def run(self, args):
         """
@@ -158,7 +161,7 @@ class Extract(Runner):
             execute(babel_cmd, working_directory=app_dir, stderr=stderr)
 
         # Segment the generated files.
-        segmented_files = segment_pofiles(configuration, "en")
+        segmented_files = segment_pofiles(configuration, configuration.source_locale)
         files_to_clean.update(segmented_files)
 
         # Finish each file.

--- a/i18n/segment.py
+++ b/i18n/segment.py
@@ -63,7 +63,6 @@ def segment_pofile(filename, segments):
     """
     reading_msg = "Reading {num} entries from {file}"
     writing_msg = "Writing {num} entries to {file}"
-
     source_po = polib.pofile(filename)
     LOG.info(reading_msg.format(file=filename, num=len(source_po)))  # pylint: disable=logging-format-interpolation
 
@@ -107,7 +106,7 @@ def segment_pofile(filename, segments):
     files_written = set()
     for segment_file, pofile in segment_po_files.items():
         out_file = filename.dirname() / segment_file
-        if len(pofile) == 0:
+        if not pofile:
             LOG.error("No messages to write to %s, did you run segment twice?", out_file)
         else:
             LOG.info(writing_msg.format(file=out_file, num=len(pofile)))  # pylint: disable=logging-format-interpolation

--- a/i18n/transifex.py
+++ b/i18n/transifex.py
@@ -151,8 +151,7 @@ def get_new_header(configuration, pofile):
     team = pofile.metadata.get('Language-Team', None)
     if not team:
         return TRANSIFEX_HEADER.format(configuration.TRANSIFEX_URL)
-    else:
-        return TRANSIFEX_HEADER.format(team)
+    return TRANSIFEX_HEADER.format(team)
 
 
 class Transifex(Runner):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='edx-i18n-tools',
-    version='0.3.9',
+    version='0.3.10',
     description='edX Internationalization Tools',
     author='edX',
     author_email='oscm@edx.org',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,12 +2,12 @@
 Initialization for unit tests.
 """
 
-from path import Path
+from path import Path as path
 from unittest import TestCase
 
 from i18n import config
 
-TEST_DATA_DIR = Path('.').abspath() / 'tests' / 'data'
+TEST_DATA_DIR = path('.').abspath() / 'tests' / 'data'
 MOCK_APPLICATION_DIR = TEST_DATA_DIR / 'mock-application'
 MOCK_DJANGO_APP_DIR = TEST_DATA_DIR / 'mock-django-app'
 
@@ -16,6 +16,32 @@ class I18nToolTestCase(TestCase):
     """
     Base class for all i18n tool test cases.
     """
-    def setUp(self):
+    def setUp(self, root_dir=MOCK_APPLICATION_DIR, preserve_locale_paths=None, clean_paths=None):
         super(I18nToolTestCase, self).setUp()
-        self.configuration = config.Configuration(root_dir=MOCK_APPLICATION_DIR)
+        self.configuration = config.Configuration(root_dir=root_dir)
+        self.preserve_locale_paths = preserve_locale_paths if preserve_locale_paths is not None else []
+        self.clean_paths = clean_paths if clean_paths is not None else []
+
+        # Copy off current state of original locale dirs
+        for locale_path in self.preserve_locale_paths:
+            tmp = self._get_tmp_locale_path(locale_path)
+            path.rmtree_p(path(tmp))
+            path.copytree(path(locale_path), path(tmp))
+
+    def tearDown(self):
+        # Restore previous locale dir state
+        for locale_path in self.preserve_locale_paths:
+            tmp = self._get_tmp_locale_path(locale_path)
+            path.rmtree_p(path(locale_path))
+            path.copytree(path(tmp), path(locale_path))
+            path.rmtree(path(tmp))
+
+        # Remove any temporary / created paths
+        for dirty_path in self.clean_paths:
+            path.rmtree_p(path(dirty_path))
+            path.rmtree_p(path(self._get_tmp_locale_path(dirty_path)))
+
+
+    @staticmethod
+    def _get_tmp_locale_path(original_path):
+        return "{}_tmp".format(original_path)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,17 +16,10 @@ class I18nToolTestCase(TestCase):
     """
     Base class for all i18n tool test cases.
     """
-    def setUp(self, root_dir=MOCK_APPLICATION_DIR, preserve_locale_paths=None, clean_paths=None):
-        super(I18nToolTestCase, self).setUp()
-        self.configuration = config.Configuration(root_dir=root_dir)
-        self.preserve_locale_paths = preserve_locale_paths if preserve_locale_paths is not None else []
-        self.clean_paths = clean_paths if clean_paths is not None else []
 
-        # Copy off current state of original locale dirs
-        for locale_path in self.preserve_locale_paths:
-            tmp = self._get_tmp_locale_path(locale_path)
-            path.rmtree_p(path(tmp))
-            path.copytree(path(locale_path), path(tmp))
+    configuration = None
+    preserve_locale_paths = []
+    clean_paths = []
 
     def tearDown(self):
         # Restore previous locale dir state
@@ -41,6 +34,16 @@ class I18nToolTestCase(TestCase):
             path.rmtree_p(path(dirty_path))
             path.rmtree_p(path(self._get_tmp_locale_path(dirty_path)))
 
+    def _setup_i18n_test_config(self, root_dir=MOCK_APPLICATION_DIR, preserve_locale_paths=None, clean_paths=None):
+        self.configuration = config.Configuration(root_dir=root_dir)
+        self.preserve_locale_paths = preserve_locale_paths if preserve_locale_paths is not None else []
+        self.clean_paths = clean_paths if clean_paths is not None else []
+
+        # Copy off current state of original locale dirs
+        for locale_path in self.preserve_locale_paths:
+            tmp = self._get_tmp_locale_path(locale_path)
+            path.rmtree_p(path(tmp))
+            path.copytree(path(locale_path), path(tmp))
 
     @staticmethod
     def _get_tmp_locale_path(original_path):

--- a/tests/data/mock-application/conf/locale/config.yaml
+++ b/tests/data/mock-application/conf/locale/config.yaml
@@ -2,6 +2,11 @@
 # Configuration for i18n workflow.
 TRANSIFEX_URL: 'https://www.transifex.com/open-edx/edx-platform/'
 
+source_locale: mock
+
+edx_lang_map:
+    mock: mock_mapped
+
 locales:
     - en  # English - Source Language
     - fr

--- a/tests/test_changed.py
+++ b/tests/test_changed.py
@@ -13,7 +13,8 @@ class TestChanged(I18nToolTestCase):
     """
     Tests functionality of i18n/changed.py
     """
-    def setUp(self):
+    def setUp(self, root_dir=MOCK_APPLICATION_DIR, preserve_locale_paths=None, clean_paths=None):
+        super(TestChanged, self).setUp()
         self.changed = Changed()
 
     def test_detect_changes(self):
@@ -26,11 +27,13 @@ class TestChanged(I18nToolTestCase):
 
         self.assertFalse(self.changed.detect_changes())
 
-        copyfile(file_name, copy)  # Copy the .po file
-        remove(file_name)  # Make changes to the .po file
-        self.assertTrue(self.changed.detect_changes())  # Detect changes made to the .po file
-        copyfile(copy, file_name)  # Return .po file to its previous state
-        remove(copy)  # Delete copy of .po file
+        try:
+            copyfile(file_name, copy)  # Copy the .po file
+            remove(file_name)  # Make changes to the .po file
+            self.assertTrue(self.changed.detect_changes())  # Detect changes made to the .po file
+        finally:
+            copyfile(copy, file_name)  # Return .po file to its previous state
+            remove(copy)  # Delete copy of .po file
 
     def test_do_not_detect_changes(self):
         """
@@ -39,11 +42,13 @@ class TestChanged(I18nToolTestCase):
         file_name = 'test_requirements.txt'
         copy = 'test_requirements_copy.txt'
 
-        copyfile(file_name, copy)  # Copy the .txt file
-        remove(file_name)  # Make changes to the .txt file
-        self.assertFalse(self.changed.detect_changes())  # Do not detect changes made to the .txt file
-        copyfile(copy, file_name)  # Return .txt file to its previous state
-        remove(copy)  # Delete copy of .txt file
+        try:
+            copyfile(file_name, copy)  # Copy the .txt file
+            remove(file_name)  # Make changes to the .txt file
+            self.assertFalse(self.changed.detect_changes())  # Do not detect changes made to the .txt file
+        finally:
+            copyfile(copy, file_name)  # Return .txt file to its previous state
+            remove(copy)  # Delete copy of .txt file
 
     @ddt.data(
         (False, 'Source translation files are current.'),

--- a/tests/test_changed.py
+++ b/tests/test_changed.py
@@ -13,8 +13,9 @@ class TestChanged(I18nToolTestCase):
     """
     Tests functionality of i18n/changed.py
     """
-    def setUp(self, root_dir=MOCK_APPLICATION_DIR, preserve_locale_paths=None, clean_paths=None):
+    def setUp(self):
         super(TestChanged, self).setUp()
+        self._setup_i18n_test_config()
         self.changed = Changed()
 
     def test_detect_changes(self):

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -15,7 +15,7 @@ class TestDummy(I18nToolTestCase):
     Tests functionality of i18n/dummy.py
     """
 
-    def setUp(self, root_dir=MOCK_APPLICATION_DIR, preserve_locale_paths=None, clean_paths=None):
+    def setUp(self):
         super(TestDummy, self).setUp()
         self.converter = dummy.Dummy()
 

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -6,7 +6,7 @@ from polib import POEntry
 
 from i18n import dummy
 
-from . import I18nToolTestCase
+from . import I18nToolTestCase,MOCK_APPLICATION_DIR
 
 
 @ddt.ddt
@@ -15,7 +15,8 @@ class TestDummy(I18nToolTestCase):
     Tests functionality of i18n/dummy.py
     """
 
-    def setUp(self):
+    def setUp(self, root_dir=MOCK_APPLICATION_DIR, preserve_locale_paths=None, clean_paths=None):
+        super(TestDummy, self).setUp()
         self.converter = dummy.Dummy()
 
     def assertUnicodeEquals(self, str1, str2):

--- a/tests/test_transifex.py
+++ b/tests/test_transifex.py
@@ -17,6 +17,7 @@ class TestTransifex(I18nToolTestCase):
 
     def setUp(self):
         super(TestTransifex, self).setUp()
+        self._setup_i18n_test_config()
         self.patcher = mock.patch('i18n.transifex.execute')
         self.addCleanup(self.patcher.stop)
         self.mock_execute = self.patcher.start()

--- a/tests/test_transifex.py
+++ b/tests/test_transifex.py
@@ -57,8 +57,8 @@ class TestTransifex(I18nToolTestCase):
         # Call the pull command
         transifex.pull(self.configuration)
 
-        # conf/locale/config.yaml specifies two non-source locales, 'fr' and 'zh_CN'
         call_args = [
+            ('tx pull -f --mode=reviewed -l en',),
             ('tx pull -f --mode=reviewed -l fr',),
             ('tx pull -f --mode=reviewed -l zh_CN',),
         ]
@@ -73,6 +73,8 @@ class TestTransifex(I18nToolTestCase):
 
         # conf/locale/config.yaml specifies two non-source locales, 'fr' and 'zh_CN'
         call_args = [
+            ('tx pull -f --mode=reviewed -l en -r foo.1',),
+            ('tx pull -f --mode=reviewed -l en -r foo.2',),
             ('tx pull -f --mode=reviewed -l fr -r foo.1',),
             ('tx pull -f --mode=reviewed -l fr -r foo.2',),
             ('tx pull -f --mode=reviewed -l zh_CN -r foo.1',),


### PR DESCRIPTION
- Added edx_lang_map to config for mapping lang codes to something
different than Transifex has
- Re-enabled skipped tests
- Improved cleanup of test data dirs when tests fail
- Make extract respect config source_locale