### PR TITLE
Return non-zero exit code on validation error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,11 @@ Details of the config.yaml file are in `edx-platform/conf/locale/config.yaml
 
 Changes
 =======
+v0.4.0
+-------
+
+* The validate command returns a non-zero exit code when problems are detected with the translation files.
+
 v0.3.10
 -------
 

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '0.3.10'
+__version__ = '0.4.0'
 
 
 class Runner:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='edx-i18n-tools',
-    version='0.3.10',
+    version='0.4.0',
     description='edX Internationalization Tools',
     author='edX',
     author_email='oscm@edx.org',


### PR DESCRIPTION
Changes the the validate command to return a non-zero exit code when problems are detected with the translation files. This is useful when using the validate command with Travis and other CI solutions to ensure that new translations that are automatically downloaded and committed to projects are valid.