### PR TITLE
Fix bug preventing the use of --empty option with validate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,11 @@ Details of the config.yaml file are in `edx-platform/conf/locale/config.yaml
 
 Changes
 =======
+v0.4.1
+-------
+
+* Fixes bug preventing the use of --empty with The validate command.
+
 v0.4.0
 -------
 

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 
 
 class Runner:

--- a/i18n/validate.py
+++ b/i18n/validate.py
@@ -241,7 +241,7 @@ class Validate(Runner):
 
         if not languages:
             # validate all languages
-            if validate_po_files(self.configuration, locale_dir, args.empty):
+            if validate_po_files(self.configuration, locale_dir, report_empty=args.empty):
                 exit_code = 1
         else:
             # languages will be a list of language codes; test each language.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='edx-i18n-tools',
-    version='0.4.0',
+    version='0.4.1',
     description='edX Internationalization Tools',
     author='edX',
     author_email='oscm@edx.org',


### PR DESCRIPTION
Updates a call to `validate_po_file` to ensure arguments are passed correctly. 