### PR TITLE
fix bug preventing from loading config.yaml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,11 @@ Details of the config.yaml file are in `edx-platform/conf/locale/config.yaml
 
 Changes
 =======
+0.4.2
+-------
+
+* Specified utf-8 encoding for .yaml file.
+
 v0.4.1
 -------
 

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'
 
 
 class Runner:

--- a/i18n/config.py
+++ b/i18n/config.py
@@ -1,6 +1,7 @@
 """
 Reads configuration specifications.
 """
+import io
 import os
 
 import yaml
@@ -59,7 +60,7 @@ class Configuration(object):
         """
         if not os.path.exists(filename):
             raise Exception("Configuration file cannot be found: %s" % filename)
-        with open(filename) as stream:
+        with io.open(filename, encoding='UTF-8') as stream:
             return yaml.safe_load(stream)
 
     def __getattr__(self, name):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='edx-i18n-tools',
-    version='0.4.1',
+    version='0.4.2',
     description='edX Internationalization Tools',
     author='edX',
     author_email='oscm@edx.org',


### PR DESCRIPTION
For automated jenkins job i18n was not able to load the config file
`13:28:37 i18n_tool extract -vv
13:28:37 /edx/var/jenkins/jobs/translations/jobs/edx-platform-push_translations/workspace/ecommerce-scripts/edx-platform/conf/locale/config.yaml
13:28:37 Traceback (most recent call last):
13:28:37   File "/edx/var/jenkins/shiningpanda/jobs/21b7fcb9/virtualenvs/4418f485/bin/i18n_tool", line 11, in <module>
13:28:37     sys.exit(main())
13:28:37   File "/edx/var/jenkins/shiningpanda/jobs/21b7fcb9/virtualenvs/4418f485/lib/python3.5/site-packages/i18n/main.py", line 60, in main
13:28:37     return module.main()
13:28:37   File "/edx/var/jenkins/shiningpanda/jobs/21b7fcb9/virtualenvs/4418f485/lib/python3.5/site-packages/i18n/__init__.py", line 50, in __call__
13:28:37     self.configuration = config.Configuration(filename=args.config, root_dir=root_dir)
13:28:37   File "/edx/var/jenkins/shiningpanda/jobs/21b7fcb9/virtualenvs/4418f485/lib/python3.5/site-packages/i18n/config.py", line 35, in __init__
13:28:37     self._config = self.read_config(self._filename)
13:28:37   File "/edx/var/jenkins/shiningpanda/jobs/21b7fcb9/virtualenvs/4418f485/lib/python3.5/site-packages/i18n/config.py", line 67, in read_config
13:28:37     return yaml.load(stream)
13:28:37   File "/edx/var/jenkins/shiningpanda/jobs/21b7fcb9/virtualenvs/4418f485/lib/python3.5/site-packages/yaml/__init__.py", line 70, in load
13:28:37     loader = Loader(stream)
13:28:37   File "/edx/var/jenkins/shiningpanda/jobs/21b7fcb9/virtualenvs/4418f485/lib/python3.5/site-packages/yaml/loader.py", line 34, in __init__
13:28:37     Reader.__init__(self, stream)
13:28:37   File "/edx/var/jenkins/shiningpanda/jobs/21b7fcb9/virtualenvs/4418f485/lib/python3.5/site-packages/yaml/reader.py", line 85, in __init__
13:28:37     self.determine_encoding()
13:28:37   File "/edx/var/jenkins/shiningpanda/jobs/21b7fcb9/virtualenvs/4418f485/lib/python3.5/site-packages/yaml/reader.py", line 124, in determine_encoding
13:28:37     self.update_raw()
13:28:37   File "/edx/var/jenkins/shiningpanda/jobs/21b7fcb9/virtualenvs/4418f485/lib/python3.5/site-packages/yaml/reader.py", line 178, in update_raw
13:28:37     data = self.stream.read(size)
13:28:37   File "/edx/var/jenkins/shiningpanda/jobs/21b7fcb9/virtualenvs/4418f485/lib/python3.5/encodings/ascii.py", line 26, in decode
13:28:37     return codecs.ascii_decode(input, self.errors)[0]
13:28:37 UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1914: ordinal not in range(128)
`
