### PR TITLE
-force argument to skip merge files check in Validate script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,12 +85,17 @@ Details of the config.yaml file are in `edx-platform/conf/locale/config.yaml
 
 Changes
 =======
-0.4.3
+v0.4.4
+-------
+
+* Added check-all (check all po files) argument to validate command.
+
+v0.4.3
 -------
 
 * Specify Language header for generated dummy po files.
 
-0.4.2
+v0.4.2
 -------
 
 * Specified utf-8 encoding for .yaml file.

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '0.4.3'
+__version__ = '0.4.4'
 
 
 class Runner:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='edx-i18n-tools',
-    version='0.4.3',
+    version='0.4.4',
     description='edX Internationalization Tools',
     author='edX',
     author_email='oscm@edx.org',


### PR DESCRIPTION
[LEARNER-2556](https://openedx.atlassian.net/browse/LEARNER-2556)

Description:
LEARNER-2556 is responsible for adding a travis check to all idas which will be using the validate script to validate translations. for some idas. Idas using i18n_tools extract translation script create partial files for new translations. Thus when generate_merge options available in config file validate only checks partial files to check issues. This will cause problems when we are running travis check in those idas when we pull translations we want to merge them after validating them but those po files will be ignored because of the following check https://github.com/edx/i18n-tools/blob/master/i18n/validate.py#L40. This pr includes a option which will skip this check and check all po files even if merge options are there. 