### PR TITLE
Extract from jsx files too

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,11 @@ Details of the config.yaml file are in `edx-platform/conf/locale/config.yaml
 
 Changes
 =======
+v0.4.5
+-------
+
+* Extract from .jsx files too.
+
 v0.4.4
 -------
 

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '0.4.4'
+__version__ = '0.4.5'
 
 
 class Runner:

--- a/i18n/extract.py
+++ b/i18n/extract.py
@@ -128,8 +128,8 @@ class Extract(Runner):
         make_django_cmd = makemessages + ' -d django'
         execute(make_django_cmd, working_directory=configuration.root_dir, stderr=stderr)
 
-        # Extract strings from Javascript source files (*.js).
-        make_djangojs_cmd = makemessages + ' -d djangojs'
+        # Extract strings from Javascript source files (*.js, *jsx).
+        make_djangojs_cmd = makemessages + ' -d djangojs -e js,jsx'
         execute(make_djangojs_cmd, working_directory=configuration.root_dir, stderr=stderr)
 
         # makemessages creates 'django.po'. This filename is hardcoded.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='edx-i18n-tools',
-    version='0.4.4',
+    version='0.4.5',
     description='edX Internationalization Tools',
     author='edX',
     author_email='oscm@edx.org',


### PR DESCRIPTION
React files (in *.jsx) form will otherwise not be translated.

Django's parser can seemingly handle the jsx files I've thrown at it (I don't believe it's actually parsing the jsx, but just regexing for the gettext() calls, which it does alright at).