### PR TITLE
Some reliability fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,24 @@ Details of the config.yaml file are in `edx-platform/conf/locale/config.yaml
 
 Changes
 =======
+v0.4.6
+-------
+
+* Ensure that we only pull files from Transifex that are 10% done.
+  Avoids a problem with our validation code choking on empty po files
+  and avoids translations that are just getting started.
+
+* Don't complain about obviously missing files when cleaning
+  the headers of just-pulled files, and make sure that we do
+  notice the files we did actually pull.
+
+* Ensure that Plural-Forms has a valid value when extracting.
+  python-gettext will choke otherwise.
+
+* When creating a dummy po file, don't garble source strings in
+  a way that relies on the Python dictionary order. This way the
+  result will always be the same no matter the machine.
+
 v0.4.5
 -------
 

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '0.4.5'
+__version__ = '0.4.6'
 
 
 class Runner:

--- a/i18n/dummy.py
+++ b/i18n/dummy.py
@@ -46,10 +46,10 @@ class BaseDummyConverter(Converter):
     String conversion goes through a character map, then gets padded.
 
     """
-    TABLE = {}
+    TABLE = []
 
     def inner_convert_string(self, string):
-        for old, new in self.TABLE.items():
+        for old, new in self.TABLE:
             string = string.replace(old, new)
         return self.pad(string)
 
@@ -131,7 +131,7 @@ class Dummy(BaseDummyConverter):
     """
     # Substitute plain characters with accented lookalikes.
     # http://tlt.its.psu.edu/suggestions/international/web/codehtml.html#accent
-    TABLE = dict(zip(
+    TABLE = list(zip(
         u"AabCcEeIiOoUuYy",
         u"ÀäßÇçÉéÌïÖöÛüÝý"
     ))
@@ -171,7 +171,7 @@ class Dummy2(BaseDummyConverter):
     Strikes-through many letters, and turns lower-case letters upside-down.
 
     """
-    TABLE = dict(zip(
+    TABLE = list(zip(
         u"ABCDEGHIJKLOPRTUYZabcdefghijklmnopqrstuvwxyz",
         u"ȺɃȻĐɆǤĦƗɈꝀŁØⱣɌŦɄɎƵɐqɔpǝɟƃɥᴉɾʞlɯuødbɹsʇnʌʍxʎz"
     ))
@@ -181,7 +181,7 @@ class ArabicDummy(BaseDummyConverter):
     """
     A dummy converter for an RTL-like language.
     """
-    TABLE = dict(zip(
+    TABLE = list(zip(
         u"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
         u"شزذيثبلاهتنمورخحضقسفعدصطغظشزذيثبلاهتنمورخحضقسفعدصطغظ"
     ))

--- a/i18n/extract.py
+++ b/i18n/extract.py
@@ -241,6 +241,7 @@ def fix_metadata(pofile):
         'Language': 'en',
         'Last-Translator': '',
         'Language-Team': 'openedx-translation <openedx-translation@googlegroups.com>',
+        'Plural-Forms': 'nplurals=2; plural=(n != 1);',
     }
     pofile.metadata.update(fixes)
 

--- a/i18n/transifex.py
+++ b/i18n/transifex.py
@@ -56,7 +56,7 @@ def pull(configuration, *resources):
     print("Pulling conf/locale/config.yaml:locales from Transifex...")
 
     for lang in configuration.translated_locales:
-        cmd = 'tx pull -f --mode=reviewed -l {lang}'.format(lang=lang)
+        cmd = 'tx pull -f --mode=reviewed --minimum-perc=10 -l {lang}'.format(lang=lang)
         if resources:
             for resource in resources:
                 execute(cmd + ' -r {resource}'.format(resource=resource))
@@ -118,7 +118,10 @@ def clean_locale(configuration, locale):
     Iterates over machine-generated files.
     """
     dirname = configuration.get_messages_dir(locale)
-    for filename in ('django-partial.po', 'djangojs-partial.po', 'mako.po'):
+    if not dirname.exists():
+        # Happens when we have a supported locale that doesn't exist in Transifex
+        return
+    for filename in dirname.files('*.po'):
         clean_file(configuration, dirname.joinpath(filename))
 
 
@@ -127,16 +130,8 @@ def clean_file(configuration, filename):
     Strips out the warning from a translated po file about being an English source file.
     Replaces warning with a note about coming from Transifex.
     """
-    try:
-        pofile = polib.pofile(filename)
-    except Exception as exc:  # pylint: disable=broad-except
-        # An exception can occur when a language is deleted from Transifex.
-        # Don't totally fail here.
-        print(
-            "Encountered error {} with filename {} - language project may "
-            "no longer exist on Transifex".format(exc, filename)
-        )
-        return
+    pofile = polib.pofile(filename)
+
     if pofile.header.find(EDX_MARKER) != -1:
         new_header = get_new_header(configuration, pofile)
         new = pofile.header.replace(EDX_MARKER, new_header)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='edx-i18n-tools',
-    version='0.4.5',
+    version='0.4.6',
     description='edX Internationalization Tools',
     author='edX',
     author_email='oscm@edx.org',

--- a/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/django-partial.po
+++ b/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/django-partial.po
@@ -2,7 +2,7 @@
 # Copyright (C) 2015 EdX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1a\n"

--- a/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/django-studio.po
+++ b/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/django-studio.po
@@ -1,8 +1,8 @@
-# edX translation file.
+# edX community translations have been downloaded from openedx-translation <openedx-translation@googlegroups.com>.
 # Copyright (C) 2015 EdX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1a\n"

--- a/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/django.po
+++ b/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/django.po
@@ -3,36 +3,36 @@
 # Copyright (C) 2015 EdX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 # #-#-#-#-#  django-studio.po (0.1a)  #-#-#-#-#
-# edX translation file.
+# edX community translations have been downloaded from openedx-translation <openedx-translation@googlegroups.com>.
 # Copyright (C) 2015 EdX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 # #-#-#-#-#  mako.po (0.1a)  #-#-#-#-#
 # edX community translations have been downloaded from openedx-translation <openedx-translation@googlegroups.com>
 # Copyright (C) 2015 edX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 # #-#-#-#-#  mako-studio.po (0.1a)  #-#-#-#-#
-# edX translation file
+# edX community translations have been downloaded from openedx-translation <openedx-translation@googlegroups.com>
 # Copyright (C) 2015 edX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 # #-#-#-#-#  messages.po (EdX Studio)  #-#-#-#-#
-# edX translation file
+# edX community translations have been downloaded from openedx-translation <openedx-translation@googlegroups.com>
 # Copyright (C) 2013 edX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
-# 
+#
 # #-#-#-#-#  wiki.po (0.1a)  #-#-#-#-#
-# edX translation file
+# edX community translations have been downloaded from openedx-translation <openedx-translation@googlegroups.com>
 # Copyright (C) 2015 edX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1a\n"
@@ -44,9 +44,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Babel 1.3\n"
 
 #. Translators: 'Discussion' refers to the tab in the courseware that leads to
 #. the discussion forums

--- a/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/djangojs-partial.po
+++ b/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/djangojs-partial.po
@@ -2,7 +2,7 @@
 # Copyright (C) 2015 EdX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1a\n"

--- a/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/djangojs-studio.po
+++ b/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/djangojs-studio.po
@@ -1,8 +1,8 @@
-# edX translation file.
+# edX community translations have been downloaded from openedx-translation <openedx-translation@googlegroups.com>.
 # Copyright (C) 2015 EdX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1a\n"

--- a/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/djangojs.po
+++ b/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/djangojs.po
@@ -3,25 +3,25 @@
 # Copyright (C) 2015 EdX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 # #-#-#-#-#  djangojs-studio.po (0.1a)  #-#-#-#-#
-# edX translation file.
+# edX community translations have been downloaded from openedx-translation <openedx-translation@googlegroups.com>.
 # Copyright (C) 2015 EdX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 # #-#-#-#-#  underscore.po (0.1a)  #-#-#-#-#
-# edX translation file
+# edX community translations have been downloaded from openedx-translation <openedx-translation@googlegroups.com>
 # Copyright (C) 2015 edX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 # #-#-#-#-#  underscore-studio.po (0.1a)  #-#-#-#-#
-# edX translation file
+# edX community translations have been downloaded from openedx-translation <openedx-translation@googlegroups.com>
 # Copyright (C) 2015 edX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1a\n"
@@ -33,9 +33,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Babel 1.3\n"
 
 #: cms/static/coffee/src/views/tabs.js
 #: cms/static/coffee/src/xblock/cms.runtime.v1.js

--- a/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/mako-studio.po
+++ b/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/mako-studio.po
@@ -1,8 +1,8 @@
-# edX translation file
+# edX community translations have been downloaded from openedx-translation <openedx-translation@googlegroups.com>
 # Copyright (C) 2015 edX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1a\n"
@@ -14,9 +14,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Babel 1.3\n"
 
 #: cms/templates/404.html
 msgid "The page that you were looking for was not found."

--- a/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/mako.po
+++ b/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/mako.po
@@ -2,7 +2,7 @@
 # Copyright (C) 2015 edX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1a\n"
@@ -14,9 +14,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Babel 1.3\n"
 
 #: cms/templates/404.html cms/templates/error.html
 #: lms/templates/static_templates/404.html

--- a/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/messages.po
+++ b/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/messages.po
@@ -1,7 +1,7 @@
-# edX translation file
+# edX community translations have been downloaded from translation team <translation_team@edx.org>
 # Copyright (C) 2013 edX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: EdX Studio\n"

--- a/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/underscore-studio.po
+++ b/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/underscore-studio.po
@@ -1,8 +1,8 @@
-# edX translation file
+# edX community translations have been downloaded from openedx-translation <openedx-translation@googlegroups.com>
 # Copyright (C) 2015 edX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1a\n"
@@ -14,9 +14,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Babel 1.3\n"
 
 #: cms/templates/js/active-video-upload-list.underscore
 msgid "Drag and drop or click here to upload video files."

--- a/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/underscore.po
+++ b/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/underscore.po
@@ -1,8 +1,8 @@
-# edX translation file
+# edX community translations have been downloaded from openedx-translation <openedx-translation@googlegroups.com>
 # Copyright (C) 2015 edX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1a\n"
@@ -14,9 +14,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Babel 1.3\n"
 
 #: cms/templates/js/add-xblock-component-menu-problem.underscore
 #: cms/templates/js/add-xblock-component-menu.underscore

--- a/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/wiki.po
+++ b/tests/data/mock-application/conf/locale/fr/LC_MESSAGES/wiki.po
@@ -1,8 +1,8 @@
-# edX translation file
+# edX community translations have been downloaded from openedx-translation <openedx-translation@googlegroups.com>
 # Copyright (C) 2015 edX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1a\n"
@@ -14,9 +14,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 1.3\n"
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Babel 1.3\n"
 
 #: wiki/admin.py wiki/models/article.py
 msgid "created"

--- a/tests/data/mock-django-app/locale/mock/LC_MESSAGES/django-partial.po
+++ b/tests/data/mock-django-app/locale/mock/LC_MESSAGES/django-partial.po
@@ -2,7 +2,7 @@
 # Copyright (C) 2015 EdX
 # This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
 # EdX Team <info@edx.org>, 2015.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1a\n"

--- a/tests/test_transifex.py
+++ b/tests/test_transifex.py
@@ -59,9 +59,9 @@ class TestTransifex(I18nToolTestCase):
         transifex.pull(self.configuration)
 
         call_args = [
-            ('tx pull -f --mode=reviewed -l en',),
-            ('tx pull -f --mode=reviewed -l fr',),
-            ('tx pull -f --mode=reviewed -l zh_CN',),
+            ('tx pull -f --mode=reviewed --minimum-perc=10 -l en',),
+            ('tx pull -f --mode=reviewed --minimum-perc=10 -l fr',),
+            ('tx pull -f --mode=reviewed --minimum-perc=10 -l zh_CN',),
         ]
         self.assertEqual(
             call_args,
@@ -74,12 +74,12 @@ class TestTransifex(I18nToolTestCase):
 
         # conf/locale/config.yaml specifies two non-source locales, 'fr' and 'zh_CN'
         call_args = [
-            ('tx pull -f --mode=reviewed -l en -r foo.1',),
-            ('tx pull -f --mode=reviewed -l en -r foo.2',),
-            ('tx pull -f --mode=reviewed -l fr -r foo.1',),
-            ('tx pull -f --mode=reviewed -l fr -r foo.2',),
-            ('tx pull -f --mode=reviewed -l zh_CN -r foo.1',),
-            ('tx pull -f --mode=reviewed -l zh_CN -r foo.2',),
+            ('tx pull -f --mode=reviewed --minimum-perc=10 -l en -r foo.1',),
+            ('tx pull -f --mode=reviewed --minimum-perc=10 -l en -r foo.2',),
+            ('tx pull -f --mode=reviewed --minimum-perc=10 -l fr -r foo.1',),
+            ('tx pull -f --mode=reviewed --minimum-perc=10 -l fr -r foo.2',),
+            ('tx pull -f --mode=reviewed --minimum-perc=10 -l zh_CN -r foo.1',),
+            ('tx pull -f --mode=reviewed --minimum-perc=10 -l zh_CN -r foo.2',),
         ]
         self.assertEqual(
             call_args,
@@ -102,10 +102,6 @@ class TestTransifex(I18nToolTestCase):
     def test_clean_locale(self):
         with mock.patch('i18n.transifex.clean_file') as patched:
             transifex.clean_locale(self.configuration, 'fr')
-            self.assertEqual(3, patched.call_count)
-            call_args = ['django-partial.po', 'djangojs-partial.po', 'mako.po']
-            for callarg, expected in zip(patched.call_args_list, call_args):
-                self.assertEqual(
-                    callarg[0][1].name,
-                    expected
-                )
+            self.assertEqual(12, patched.call_count)
+            for callarg in patched.call_args_list:
+                self.assertRegexpMatches(callarg[0][1].name, '.*\.po')


### PR DESCRIPTION
1) Ensure that we only pull files from Transifex that are 10% done.
  Avoids a problem with our validation code choking on empty po files
  and avoids translations that are just getting started.
   https://github.com/edx/i18n-tools/issues/71

2) Don't complain about obviously missing files when cleaning
   the headers of just-pulled files, and make sure that we do
   notice the files we did actually pull.
   https://github.com/edx/i18n-tools/issues/69

3) Ensure that Plural-Forms has a valid value when extracting.
   python-gettext will choke otherwise.
   https://github.com/edx/i18n-tools/issues/68

4) When creating a dummy po file, don't garble source strings in
   a way that relies on the Python dictionary order. This way the
   result will always be the same no matter the machine.

The test file changes are just a result of running pytest with the latest code.