### PR TITLE
Lint po files to forbid adding HTML

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,13 @@ Details of the config.yaml file are in `edx-platform/conf/locale/config.yaml
 
 Changes
 =======
+v0.4.7
+-------
+
+* Test that tag validation catches HTML added to translations.
+
+* When tag validation finds differences, output should be deterministic.
+
 v0.4.6
 -------
 

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '0.4.6'
+__version__ = '0.4.7'
 
 
 class Runner:

--- a/i18n/validate.py
+++ b/i18n/validate.py
@@ -161,8 +161,8 @@ def check_messages(filename, report_empty=False):
 
             # Check if tags don't match
             if id_tags != tx_tags:
-                id_has = u", ".join(u'"{}"'.format(t) for t in id_tags - tx_tags)
-                tx_has = u", ".join(u'"{}"'.format(t) for t in tx_tags - id_tags)
+                id_has = u", ".join(sorted(u'"{}"'.format(t) for t in id_tags - tx_tags))
+                tx_has = u", ".join(sorted(u'"{}"'.format(t) for t in tx_tags - id_tags))
                 if id_has and tx_has:
                     diff = u"{} vs {}".format(id_has, tx_has)
                 elif id_has:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='edx-i18n-tools',
-    version='0.4.6',
+    version='0.4.7',
     description='edX Internationalization Tools',
     author='edX',
     author_email='oscm@edx.org',

--- a/tests/data/validation_problems.po
+++ b/tests/data/validation_problems.po
@@ -22,6 +22,10 @@ msgstr "One tag: {one} and not two"
 msgid "One tag: {one}"
 msgstr "Two tags: {one} and {two}"
 
+# HTML added to translations could create cross-site security issues
+msgid "No tags"
+msgstr "Added some <a href='https://en.wikipedia.org/wiki/HTML'>HTML</a>"
+
 # TODO: This doesn't raise a validation error: the characters comes through as
 # a surrogate pair, and so isn't a problem.  So are astral characters a
 # problem?
@@ -72,5 +76,6 @@ msgstr ""
 msgid "Look &mdash; a dog!"
 msgstr "Look -- a dog!"
 
+# <abbr> could come-and-go with translations
 msgid "The <abbr>CIA</abbr> said so"
 msgstr "The secret agency said so"

--- a/tests/test_changed.py
+++ b/tests/test_changed.py
@@ -26,6 +26,7 @@ class TestChanged(I18nToolTestCase):
         file_name = fake_locale_dir / 'LC_MESSAGES' / 'mako.po'
         copy = fake_locale_dir / 'LC_MESSAGES' / 'mako_copy.po'
 
+        # Note: this fails if you have not-yet-committed changes to test fixture .po files
         self.assertFalse(self.changed.detect_changes())
 
         try:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -37,6 +37,12 @@ VALIDATION_PROBLEMS = [
         u'"{two}" added',
     ),
     (
+        'Different tags in source and translation',
+        'No tags',
+        "Added some <a href='https://en.wikipedia.org/wiki/HTML'>HTML</a>",
+        '"</a>", "<a href=\'https://en.wikipedia.org/wiki/HTML\'>" added'
+    ),
+    (
         'Non-BMP char',
         u'Astral character (pile of poo), bad for JavaScript: \U0001f4a9',
         u'Astral character (pile of poo), bad for JavaScript: \U0001f4a9',


### PR DESCRIPTION
Added test that validate will flunk if a translation attempts to add HTML; made tag validation messages deterministic; minor comment additions

LEARNER-5537