### PR TITLE
Fix file path in call to `clean_file`

### DIFF
--- a/i18n/transifex.py
+++ b/i18n/transifex.py
@@ -122,7 +122,7 @@ def clean_locale(configuration, locale):
         # Happens when we have a supported locale that doesn't exist in Transifex
         return
     for filename in dirname.files('*.po'):
-        clean_file(configuration, dirname.joinpath(filename))
+        clean_file(configuration, filename)
 
 
 def clean_file(configuration, filename):


### PR DESCRIPTION
The call to `i18n_tool transifex --pull` fails during the call to the
`clean_translated_locales` function because the path to the *.po files
is incorrect. In `dirname.files('*.po')`, the result already includes
the path relative to the `dirname`, so it is incorrect to perform an
additional `joinpath`.