### PR TITLE
Upgrading path lib in requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: python
 
 python:
-  - 3.5
   - 3.8
 
 env:

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from . import config
 
-__version__ = '0.5.0'
+__version__ = '0.5.4'
 
 
 class Runner(object):

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,6 +3,6 @@
 
 Django
 polib
-path.py>=7.0
+path
 pyYaml
 six

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,13 +4,10 @@
 #
 #    make upgrade
 #
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in
-importlib-metadata==1.7.0  # via path
-path.py==12.4.0           # via -r requirements/base.in
-path==13.1.0              # via path.py
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in
+path==15.0.0              # via -r requirements/base.in
 polib==1.1.0              # via -r requirements/base.in
-pytz==2020.1              # via django
+pytz==2020.4              # via django
 pyyaml==5.3.1             # via -r requirements/base.in
 six==1.15.0               # via -r requirements/base.in
-sqlparse==0.3.1           # via django
-zipp==1.2.0               # via importlib-metadata
+sqlparse==0.4.1           # via django

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,22 +5,19 @@
 #    make upgrade
 #
 astroid==2.3.3            # via pylint, pylint-celery
-attrs==19.3.0             # via pytest
+attrs==20.3.0             # via pytest
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
-coverage==5.2             # via -r requirements/test.in, pytest-cov
+coverage==5.3             # via -r requirements/test.in, pytest-cov
 ddt==1.4.1                # via -r requirements/test.in
-edx-lint==1.5.0           # via -r requirements/test.in
-importlib-metadata==1.7.0  # via -r requirements/base.txt, path, pluggy, pytest
+edx-lint==1.5.2           # via -r requirements/test.in
+iniconfig==1.1.1          # via pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
-more-itertools==8.4.0     # via pytest
 packaging==20.4           # via pytest
-path.py==12.4.0           # via -r requirements/base.txt
-path==13.1.0              # via -r requirements/base.txt, path.py
-pathlib2==2.3.5           # via pytest
+path==15.0.0              # via -r requirements/base.txt
 pluggy==0.13.1            # via pytest
 polib==1.1.0              # via -r requirements/base.txt
 py==1.9.0                 # via pytest
@@ -30,13 +27,11 @@ pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via packaging
-pytest-cov==2.10.0        # via -r requirements/test.in
-pytest==5.4.3             # via pytest-cov
-pytz==2020.1              # via -r requirements/base.txt, -r requirements/test.in, django
+pytest-cov==2.10.1        # via -r requirements/test.in
+pytest==6.1.2             # via pytest-cov
+pytz==2020.4              # via -r requirements/base.txt, -r requirements/test.in, django
 pyyaml==5.3.1             # via -r requirements/base.txt
-six==1.15.0               # via -r requirements/base.txt, astroid, edx-lint, mock, packaging, pathlib2
-sqlparse==0.3.1           # via -r requirements/base.txt, django
-typed-ast==1.4.1          # via astroid
-wcwidth==0.2.5            # via pytest
+six==1.15.0               # via -r requirements/base.txt, astroid, edx-lint, mock, packaging
+sqlparse==0.4.1           # via -r requirements/base.txt, django
+toml==0.10.2              # via pytest
 wrapt==1.11.2             # via astroid
-zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -7,14 +7,11 @@
 appdirs==1.4.4            # via virtualenv
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
-importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
 six==1.15.0               # via packaging, tox, virtualenv
-toml==0.10.1              # via tox
-tox==3.17.1               # via -r requirements/tox.in
-virtualenv==20.0.27       # via tox
-zipp==1.2.0               # via importlib-metadata, importlib-resources
+toml==0.10.2              # via tox
+tox==3.20.1               # via -r requirements/tox.in
+virtualenv==20.1.0        # via tox

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -6,31 +6,27 @@
 #
 appdirs==1.4.4            # via -r requirements/tox.txt, virtualenv
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
-attrs==19.3.0             # via -r requirements/test.txt, pytest
+attrs==20.3.0             # via -r requirements/test.txt, pytest
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, edx-lint
-coverage==5.2             # via -r requirements/test.txt, coveralls, pytest-cov
-coveralls==2.1.1          # via -r requirements/travis.in
+coverage==5.3             # via -r requirements/test.txt, coveralls, pytest-cov
+coveralls==2.1.2          # via -r requirements/travis.in
 ddt==1.4.1                # via -r requirements/test.txt
 distlib==0.3.1            # via -r requirements/tox.txt, virtualenv
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/test.txt
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.txt
 docopt==0.6.2             # via coveralls
-edx-lint==1.5.0           # via -r requirements/test.txt
+edx-lint==1.5.2           # via -r requirements/test.txt
 filelock==3.0.12          # via -r requirements/tox.txt, tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via -r requirements/test.txt, -r requirements/tox.txt, path, pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via -r requirements/tox.txt, virtualenv
+iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
-more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 packaging==20.4           # via -r requirements/test.txt, -r requirements/tox.txt, pytest, tox
-path.py==12.4.0           # via -r requirements/test.txt
-path==13.1.0              # via -r requirements/test.txt, path.py
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+path==15.0.0              # via -r requirements/test.txt
 pluggy==0.13.1            # via -r requirements/test.txt, -r requirements/tox.txt, pytest, tox
 polib==1.1.0              # via -r requirements/test.txt
 py==1.9.0                 # via -r requirements/test.txt, -r requirements/tox.txt, pytest, tox
@@ -40,18 +36,15 @@ pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
 pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, -r requirements/tox.txt, packaging
-pytest-cov==2.10.0        # via -r requirements/test.txt
-pytest==5.4.3             # via -r requirements/test.txt, pytest-cov
-pytz==2020.1              # via -r requirements/test.txt, django
+pytest-cov==2.10.1        # via -r requirements/test.txt
+pytest==6.1.2             # via -r requirements/test.txt, pytest-cov
+pytz==2020.4              # via -r requirements/test.txt, django
 pyyaml==5.3.1             # via -r requirements/test.txt
 requests==2.24.0          # via coveralls
-six==1.15.0               # via -r requirements/test.txt, -r requirements/tox.txt, astroid, edx-lint, mock, packaging, pathlib2, tox, virtualenv
-sqlparse==0.3.1           # via -r requirements/test.txt, django
-toml==0.10.1              # via -r requirements/tox.txt, tox
-tox==3.17.1               # via -r requirements/tox.txt
-typed-ast==1.4.1          # via -r requirements/test.txt, astroid
-urllib3==1.25.9           # via requests
-virtualenv==20.0.27       # via -r requirements/tox.txt, tox
-wcwidth==0.2.5            # via -r requirements/test.txt, pytest
+six==1.15.0               # via -r requirements/test.txt, -r requirements/tox.txt, astroid, edx-lint, mock, packaging, tox, virtualenv
+sqlparse==0.4.1           # via -r requirements/test.txt, django
+toml==0.10.2              # via -r requirements/test.txt, -r requirements/tox.txt, pytest, tox
+tox==3.20.1               # via -r requirements/tox.txt
+urllib3==1.25.11          # via requests
+virtualenv==20.1.0        # via -r requirements/tox.txt, tox
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
-zipp==1.2.0               # via -r requirements/test.txt, -r requirements/tox.txt, importlib-metadata, importlib-resources

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35-django22,py38-django{22,30}, quality
+envlist = py38-django{22,30}, quality
 
 [pytest]
 addopts = --cov=tests --cov-report term --cov-config=.coveragerc -p no:randomly


### PR DESCRIPTION
1. Remove the `path.py` from the `base.in` file.
2. Added `path` in the `base.in` file
3. Run `make upgrade`
4. Stop testing for python3.5 as `path` is only compatible with python 3.6 and higher. 
6. Update the version in the `__init__.py`

FYI  -- @crice100 
[PROD-2223](https://openedx.atlassian.net/browse/PROD-2223)