### PR TITLE
BOM-2247: Upgrade pip-tools 

### DIFF
--- a/i18n/config.py
+++ b/i18n/config.py
@@ -109,7 +109,7 @@ class Configuration:
             base_rtl = ['ar', 'fa', 'he', 'ur']
 
             # do this to capture both 'fa' and 'fa_IR'
-            return any([lang.startswith(base_code) for base_code in base_rtl])
+            return any(lang.startswith(base_code) for base_code in base_rtl)
 
         return sorted({lang for lang in self.translated_locales if is_rtl(lang)})
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,10 +4,10 @@
 #
 #    make upgrade
 #
-django==2.2.17            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/base.in
-path==15.0.1              # via -r requirements/base.in
-polib==1.1.0              # via -r requirements/base.in
-pytz==2020.5              # via django
+django==2.2.20            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/base.in
+path==15.1.2              # via -r requirements/base.in
+polib==1.1.1              # via -r requirements/base.in
+pytz==2021.1              # via django
 pyyaml==5.4.1             # via -r requirements/base.in
 six==1.15.0               # via -r requirements/base.in
 sqlparse==0.4.1           # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,8 +13,8 @@
  
 # TODO: Many pinned dependencies should be unpinned and/or moved to this constraints file.
 
-# pip 5.0.0 only works with pip 20+ and all our VMs and containers are still installing 19.3.1 by default
-pip-tools<5.0.0
+# See https://openedx.atlassian.net/browse/BOM-2247 for details.
+pip-tools==5.3.0
 
 # mock version 4.0.0 drops support for python 3.5
 mock<4.0.0

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==2.2.17            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/base.in
+django==2.2.20            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/base.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,5 +5,8 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==4.5.1          # via -c requirements/constraints.txt, -r requirements/pip_tools.in
+pip-tools==5.3.0          # via -c requirements/constraints.txt, -r requirements/pip_tools.in
 six==1.15.0               # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,39 +4,39 @@
 #
 #    make upgrade
 #
-astroid==2.4.2            # via pylint, pylint-celery
+astroid==2.5.3            # via pylint, pylint-celery
 attrs==20.3.0             # via pytest
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, code-annotations, edx-lint
-code-annotations==1.0.2   # via edx-lint
-coverage==5.4             # via -r requirements/test.in, pytest-cov
-ddt==1.4.1                # via -r requirements/test.in
-edx-lint==3.0.2           # via -r requirements/test.in
+code-annotations==1.1.1   # via edx-lint
+coverage==5.5             # via -r requirements/test.in, pytest-cov
+ddt==1.4.2                # via -r requirements/test.in
+edx-lint==5.0.0           # via -r requirements/test.in
 iniconfig==1.1.1          # via pytest
-isort==5.7.0              # via pylint
-jinja2==2.11.2            # via code-annotations
-lazy-object-proxy==1.4.3  # via astroid
+isort==5.8.0              # via pylint
+jinja2==2.11.3            # via code-annotations
+lazy-object-proxy==1.6.0  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
-packaging==20.8           # via pytest
-path==15.0.1              # via -r requirements/base.txt
+packaging==20.9           # via pytest
+path==15.1.2              # via -r requirements/base.txt
 pbr==5.5.1                # via stevedore
 pluggy==0.13.1            # via pytest
-polib==1.1.0              # via -r requirements/base.txt
+polib==1.1.1              # via -r requirements/base.txt
 py==1.10.0                # via pytest
-pycodestyle==2.6.0        # via -r requirements/test.in
+pycodestyle==2.7.0        # via -r requirements/test.in
 pylint-celery==0.3        # via edx-lint
-pylint-django==2.4.2      # via edx-lint
+pylint-django==2.4.3      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.6.0             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.7.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.11.1        # via -r requirements/test.in
-pytest==6.2.2             # via pytest-cov
+pytest==6.2.3             # via pytest-cov
 python-slugify==4.0.1     # via code-annotations
-pytz==2020.5              # via -r requirements/base.txt, -r requirements/test.in, django
+pytz==2021.1              # via -r requirements/base.txt, -r requirements/test.in, django
 pyyaml==5.4.1             # via -r requirements/base.txt, code-annotations
-six==1.15.0               # via -r requirements/base.txt, astroid, edx-lint, mock
+six==1.15.0               # via -r requirements/base.txt, edx-lint, mock
 sqlparse==0.4.1           # via -r requirements/base.txt, django
 stevedore==3.3.0          # via code-annotations
 text-unidecode==1.3       # via python-slugify

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -7,11 +7,11 @@
 appdirs==1.4.4            # via virtualenv
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-packaging==20.8           # via tox
+packaging==20.9           # via tox
 pluggy==0.13.1            # via tox
 py==1.10.0                # via tox
 pyparsing==2.4.7          # via packaging
 six==1.15.0               # via tox, virtualenv
 toml==0.10.2              # via tox
-tox==3.21.2               # via -r requirements/tox.in
-virtualenv==20.4.0        # via tox
+tox==3.23.0               # via -r requirements/tox.in
+virtualenv==20.4.4        # via tox

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,53 +5,53 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via -r requirements/tox.txt, virtualenv
-astroid==2.4.2            # via -r requirements/test.txt, pylint, pylint-celery
+astroid==2.5.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==20.3.0             # via -r requirements/test.txt, pytest
 certifi==2020.12.5        # via requests
 chardet==4.0.0            # via requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==1.0.2   # via -r requirements/test.txt, edx-lint
-coverage==5.4             # via -r requirements/test.txt, coveralls, pytest-cov
-coveralls==3.0.0          # via -r requirements/travis.in
-ddt==1.4.1                # via -r requirements/test.txt
+code-annotations==1.1.1   # via -r requirements/test.txt, edx-lint
+coverage==5.5             # via -r requirements/test.txt, coveralls, pytest-cov
+coveralls==3.0.1          # via -r requirements/travis.in
+ddt==1.4.2                # via -r requirements/test.txt
 distlib==0.3.1            # via -r requirements/tox.txt, virtualenv
-django==2.2.17            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/test.txt, code-annotations, edx-lint
+django==2.2.20            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/test.txt, code-annotations, edx-lint
 docopt==0.6.2             # via coveralls
-edx-lint==3.0.2           # via -r requirements/test.txt
+edx-lint==5.0.0           # via -r requirements/test.txt
 filelock==3.0.12          # via -r requirements/tox.txt, tox, virtualenv
 idna==2.10                # via requests
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
-isort==5.7.0              # via -r requirements/test.txt, pylint
-jinja2==2.11.2            # via -r requirements/test.txt, code-annotations
-lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
+isort==5.8.0              # via -r requirements/test.txt, pylint
+jinja2==2.11.3            # via -r requirements/test.txt, code-annotations
+lazy-object-proxy==1.6.0  # via -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
-packaging==20.8           # via -r requirements/test.txt, -r requirements/tox.txt, pytest, tox
-path==15.0.1              # via -r requirements/test.txt
+packaging==20.9           # via -r requirements/test.txt, -r requirements/tox.txt, pytest, tox
+path==15.1.2              # via -r requirements/test.txt
 pbr==5.5.1                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, -r requirements/tox.txt, pytest, tox
-polib==1.1.0              # via -r requirements/test.txt
+polib==1.1.1              # via -r requirements/test.txt
 py==1.10.0                # via -r requirements/test.txt, -r requirements/tox.txt, pytest, tox
-pycodestyle==2.6.0        # via -r requirements/test.txt
+pycodestyle==2.7.0        # via -r requirements/test.txt
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
-pylint-django==2.4.2      # via -r requirements/test.txt, edx-lint
+pylint-django==2.4.3      # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.6.0             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.7.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, -r requirements/tox.txt, packaging
 pytest-cov==2.11.1        # via -r requirements/test.txt
-pytest==6.2.2             # via -r requirements/test.txt, pytest-cov
+pytest==6.2.3             # via -r requirements/test.txt, pytest-cov
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
-pytz==2020.5              # via -r requirements/test.txt, django
+pytz==2021.1              # via -r requirements/test.txt, django
 pyyaml==5.4.1             # via -r requirements/test.txt, code-annotations
 requests==2.25.1          # via coveralls
-six==1.15.0               # via -r requirements/test.txt, -r requirements/tox.txt, astroid, edx-lint, mock, tox, virtualenv
+six==1.15.0               # via -r requirements/test.txt, -r requirements/tox.txt, edx-lint, mock, tox, virtualenv
 sqlparse==0.4.1           # via -r requirements/test.txt, django
 stevedore==3.3.0          # via -r requirements/test.txt, code-annotations
 text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
 toml==0.10.2              # via -r requirements/test.txt, -r requirements/tox.txt, pylint, pytest, tox
-tox==3.21.2               # via -r requirements/tox.txt
-urllib3==1.26.3           # via requests
-virtualenv==20.4.0        # via -r requirements/tox.txt, tox
+tox==3.23.0               # via -r requirements/tox.txt
+urllib3==1.26.4           # via requests
+virtualenv==20.4.4        # via -r requirements/tox.txt, tox
 wrapt==1.12.1             # via -r requirements/test.txt, astroid


### PR DESCRIPTION
We are using `pip==20.0.2` in configuration, which is compatible with pip-tools up to version `5.3.0`.
The compatibility chart is available at https://github.com/jazzband/pip-tools/#versions-and-compatibility

See https://openedx.atlassian.net/browse/BOM-2247 for details.